### PR TITLE
 V1.1 - September 26, 2020

### DIFF
--- a/Assets/Lamden UI Example/LamdenExampleScene.unity
+++ b/Assets/Lamden UI Example/LamdenExampleScene.unity
@@ -7910,26 +7910,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: LamdenManager
       objectReference: {fileID: 0}
-    - target: {fileID: 2416007758763373163, guid: 6ad5094b5e0e9454c8df3c66be2bcf0c,
-        type: 3}
-      propertyPath: networkInfo.hosts.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2416007758763373163, guid: 6ad5094b5e0e9454c8df3c66be2bcf0c,
-        type: 3}
-      propertyPath: networkInfo.lamden
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 2416007758763373163, guid: 6ad5094b5e0e9454c8df3c66be2bcf0c,
-        type: 3}
-      propertyPath: networkInfo.hosts.Array.data[1]
-      value: http://167.172.126.5:18080/
-      objectReference: {fileID: 0}
-    - target: {fileID: 2416007758763373163, guid: 6ad5094b5e0e9454c8df3c66be2bcf0c,
-        type: 3}
-      propertyPath: networkInfo.currencySymbol
-      value: dTAU
-      objectReference: {fileID: 0}
     - target: {fileID: 2416007758763373162, guid: 6ad5094b5e0e9454c8df3c66be2bcf0c,
         type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Lamden UI Example/Test_Values.cs
+++ b/Assets/Lamden UI Example/Test_Values.cs
@@ -9,10 +9,14 @@ public class Test_Values : MonoBehaviour
 {
     public LamdenTest lamdenTest;
 
-    public InputField inUid, inStr, inFloat, InInt;
+    public InputField inUid, inStr, inFloat, InInt, inGetValueUIDVar, inGetValueOutput;
     public Dropdown ddBool;
 
     public Text txtStatus;
+
+    string contractName = "con_values_testing";
+    string methodName = "test_values";
+
 
     // Start is called before the first frame update
     void Start()
@@ -26,8 +30,8 @@ public class Test_Values : MonoBehaviour
         TxInfo txInfo = new TxInfo()
         {
             sender = lamdenTest.GetWallet(),
-            contractName = "con_values_testing",
-            methodName = "test_values",
+            contractName = contractName,
+            methodName = methodName,
             stampLimit = 100,
             kwargs = new Dictionary<string, KwargType>
                 {
@@ -69,5 +73,14 @@ public class Test_Values : MonoBehaviour
             if (txStatus == Transaction.TransactionStatus.Error)
                 txtStatus.text = txResponse.error;
         });
+    }
+
+    public void GetValue()
+    {
+        lamdenTest.masterNodeApi.GetVariable(
+            contractName, "S", new Dictionary<string, string>() { { "key", inGetValueUIDVar.text } }, (bool success, string result) => {
+                inGetValueOutput.text = result;
+            });
+
     }
 }

--- a/Assets/LamdenUnity/EditorTests/NetworkTests/MasterNodeApiTests.cs
+++ b/Assets/LamdenUnity/EditorTests/NetworkTests/MasterNodeApiTests.cs
@@ -18,7 +18,7 @@ namespace Tests
 
         MasterNodeApi masterNodeApiGood;
         MasterNodeApi masterNodeApiBad;
-        const string goodHost = "http://167.172.126.5:18080/";
+        const string goodHost = "https://testnet-master-1.lamden.io/";
         const string badHost = "http://127.1.1.1:18080/";
 
         NetworkInfo goodNetwork = new NetworkInfo()
@@ -61,7 +61,7 @@ namespace Tests
         public void TestSetup()
         {
             SetupGood();
-            Assert.True(masterNodeApiGood.host.Equals(goodHost));
+            Assert.AreEqual(masterNodeApiGood.host, goodHost);
             var ex = Assert.Throws<Exception>(() => masterNodeApiGood.SetNetworkInfo(null));
             Assert.That(ex.Message, Is.EqualTo("networkInfo cannot be null"));
         }
@@ -107,7 +107,7 @@ namespace Tests
         public IEnumerator GetVariableTest()
         {
             SetupGood();
-            Dictionary<string, string> keys = new Dictionary<string, string> { {"key", "testing:str"} };
+            Dictionary<string, string> keys = new Dictionary<string, string> { {"key", "testing:Str"} };
             masterNodeApiGood.GetVariable("con_values_testing", "S", keys, (bool callCompleted, string json) =>
             {
                 Debug.Log($"GetVariableTest results: {json}");
@@ -166,7 +166,7 @@ namespace Tests
         public IEnumerator CheckTransactionTest()
         {
             SetupGood();
-            string hash = "3d2b98180bb429a7ca2e5fd81f0cc5cf30a4af6bf4f83eca90685472769703b7";
+            string hash = "440d856d3b21b76a40fc8cbc4a79e168225ec1688a470cdc43eb8329bf36ebb0";
             masterNodeApiGood.CheckTransaction(null, hash, (bool callCompleted, string json) =>
             {
                 Debug.Log($"CheckTransactionTest results: {json}");

--- a/Assets/LamdenUnity/EditorTests/TransactionTests/TransactionTests.cs
+++ b/Assets/LamdenUnity/EditorTests/TransactionTests/TransactionTests.cs
@@ -15,7 +15,7 @@ namespace Tests
         bool calledBack;
 
         MasterNodeApi masterNodeApiGood;
-        const string goodHost = "http://167.172.126.5:18080/";
+        const string goodHost = "https://testnet-master-1.lamden.io";
 
         NetworkInfo goodNetwork = new NetworkInfo()
         {
@@ -92,7 +92,7 @@ namespace Tests
                 stampLimit = 100,
                 kwargs = new Dictionary<string, KwargType>
                 {
-                    {"UID", new KT_UID("testing2")},
+                    {"UID", new KT_UID("testing")},
                     {"Str", new KT_String("this is another string")},
                     {"Float", new KT_Numeric(1.1f)},
                     {"Int", new KT_Int(2)},

--- a/Assets/LamdenUnity/Prefabs/LamdenManager.prefab
+++ b/Assets/LamdenUnity/Prefabs/LamdenManager.prefab
@@ -46,8 +46,8 @@ MonoBehaviour:
   timeout: 10000
   networkInfo:
     hosts:
-    - http://167.172.126.5:18080/
+    - https://testnet-master-1.lamden.io/
     networkType: testnet
-    currencySymbol: TAU
+    currencySymbol: dTAU
     lamden: 1
-    blockExplorer: https://explorer.lamden.io
+    blockExplorer: https://testnet.lamden.io/

--- a/Assets/LamdenUnity/version.md
+++ b/Assets/LamdenUnity/version.md
@@ -1,1 +1,7 @@
+V1.1 - September 26, 2020
+
+- Changed some of the test cases that were not working after the testnet wipe
+- Changed the default URL to be the DNS name for the testnet for clarity
+- Added a new UI example to get a value contract's hash variable
+
 V1.0 - Intital Release September 15, 2020

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -38,7 +38,6 @@ GraphicsSettings:
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 16003, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -647,7 +647,7 @@ PlayerSettings:
   il2cppCompilerConfiguration: {}
   managedStrippingLevel: {}
   incrementalIl2cppBuild: {}
-  allowUnsafeCode: 0
+  allowUnsafeCode: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 0


### PR DESCRIPTION
- Changed some of the test cases that were not working after the testnet wipe
- Changed the default URL to be the DNS name for the testnet for clarity
- Added a new UI example to get a value contract's hash variable